### PR TITLE
Honor passed password for UserFactory

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/factories.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/factories.py
@@ -12,7 +12,7 @@ class UserFactory(DjangoModelFactory):
 
     @post_generation
     def password(self, create: bool, extracted: Sequence[Any], **kwargs):
-        password = Faker(
+        password = extracted if extracted else Faker(
             "password",
             length=42,
             special_chars=True,


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

`UserFactory` accepts user password password so that `client` can use it to log in.


## Rationale

[//]: # (Why does the project need that?)

Whereas it is understandable that `user` fixture always have random password, direct use of `UserFactory(username, password)` should not silently ignore `password`, which causes confusion when users use `client.login()` to login with the same password.


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

#2405 has some a use case.

